### PR TITLE
GS-330 Reset Other Users' Completion Capability

### DIFF
--- a/bulkresetcompletion.php
+++ b/bulkresetcompletion.php
@@ -36,7 +36,7 @@ $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 require_login($course);
 
 $context = context_course::instance($course->id);
-require_capability('local/recompletion:manage', $context);
+require_capability('local/recompletion:resetothercompletion', $context);
 
 $PAGE->set_url('/local/recompletion/editcompletion.php', ['id' => $course->id]);
 

--- a/db/access.php
+++ b/db/access.php
@@ -46,6 +46,15 @@ $capabilities = [
             'manager' => CAP_ALLOW,
         ]
     ],
+    'local/recompletion:resetothercompletion' => [
+        'riskbitmask' => RISK_XSS,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+    ],
     'local/recompletion:bulkoperations' => [
         'riskbitmask' => RISK_XSS,
         'captype' => 'write',

--- a/editcompletion.php
+++ b/editcompletion.php
@@ -33,7 +33,7 @@ $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
 require_login($course);
 
 $context = context_course::instance($course->id);
-require_capability('local/recompletion:manage', $context);
+require_capability('local/recompletion:resetothercompletion', $context);
 
 $PAGE->set_url('/local/recompletion/editcompletion.php', array('id' => $course->id));
 if (empty($users) && empty($userid)) {

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -45,6 +45,7 @@ $string['recompletionsettingssaved'] = 'Recompletion settings saved';
 $string['recompletion:manage'] = 'Allow course recompletion settings to be changed';
 $string['recompletion:bulkoperations'] = 'Bulk operations';
 $string['recompletion:resetmycompletion'] = 'Reset my own completion';
+$string['recompletion:resetothercompletion'] = 'Reset other users\' completion';
 $string['resetmycompletion'] = 'Reset my activity completion';
 $string['recompletiontask'] = 'Check for users that need to recomplete';
 $string['completionnotenabled'] = 'Completion is not enabled in this course';

--- a/lib.php
+++ b/lib.php
@@ -50,9 +50,11 @@ function local_recompletion_extend_navigation_course($navigation, $course, $cont
         $name = get_string('pluginname', 'local_recompletion');
         $navigation->add($name, $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/settings', ''));
 
+    }
+
+    if (has_capability('local/recompletion:resetothercompletion', $context)) {
         $url = new moodle_url('/local/recompletion/participants.php', array('id' => $course->id));
         $name = get_string('modifycompletiondates', 'local_recompletion');
         $navigation->add($name, $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/settings', ''));
-
     }
 }

--- a/resetcompletion.php
+++ b/resetcompletion.php
@@ -43,7 +43,7 @@ if (empty($userid)) {
 $context = context_course::instance($course->id);
 if ($USER->id <> $userid) {
     $cancelurl = new moodle_url('/local/recompletion/participants.php', array('id' => $course->id));
-    require_capability('local/recompletion:manage', $context);
+    require_capability('local/recompletion:resetothercompletion', $context);
     $user = $DB->get_record('user', array('id' => $userid));
 } else {
     $cancelurl = course_get_url($course);

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2023112707;
+$plugin->version   = 2023112708;
 $plugin->release   = 2023112707;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2022112805; // Requires 4.1.


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Adds a capability, 'local/recompletion:resetothercompletion', which allows resetting the completion of other users without requiring access to the recompletion settings via 'local/recompletion:manage'.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
